### PR TITLE
allow app.asar files

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -34,7 +34,7 @@ module.exports = (grunt) ->
     {certificateFile, certificatePassword} = config
 
     appResourcesDirectory = path.join(appDirectory, 'resources', 'app')
-    if grunt.file.exists(appResourcesDirectory) and grunt.file.isDir(appResourcesDirectory)
+    if grunt.file.isDir(appResourcesDirectory)
       appMetadata = grunt.file.readJSON(path.join(appResourcesDirectory, 'package.json'))
     else
       appMetadata = JSON.parse(asar.extractFile(path.join(appDirectory, 'resources', 'app.asar'), 'package.json'))

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,6 @@
 ChildProcess = require 'child_process'
 fs = require 'fs'
+asar = require 'asar'
 path = require 'path'
 temp = require 'temp'
 _ = require 'underscore'
@@ -32,7 +33,11 @@ module.exports = (grunt) ->
 
     {certificateFile, certificatePassword} = config
 
-    appMetadata = grunt.file.readJSON(path.join(appDirectory, 'resources', 'app', 'package.json'))
+    appDir = path.join(appDirectory, 'resources', 'app')
+    if grunt.file.exists(appDir) and grunt.file.isDir(appDir)
+      appMetadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
+    else
+      appMetadata = JSON.parse(asar.extractFile(path.join(appDirectory, 'resources', 'app.asar'), 'package.json'))
     metadata = _.extend({}, appMetadata, config)
 
     metadata.authors ?= metadata.author?.name ? metadata.author ? ''

--- a/index.coffee
+++ b/index.coffee
@@ -33,9 +33,9 @@ module.exports = (grunt) ->
 
     {certificateFile, certificatePassword} = config
 
-    appDir = path.join(appDirectory, 'resources', 'app')
-    if grunt.file.exists(appDir) and grunt.file.isDir(appDir)
-      appMetadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
+    appResourcesDirectory = path.join(appDirectory, 'resources', 'app')
+    if grunt.file.exists(appResourcesDirectory) and grunt.file.isDir(appResourcesDirectory)
+      appMetadata = grunt.file.readJSON(path.join(appResourcesDirectory, 'package.json'))
     else
       appMetadata = JSON.parse(asar.extractFile(path.join(appDirectory, 'resources', 'app.asar'), 'package.json'))
     metadata = _.extend({}, appMetadata, config)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "temp": "^0.8.1",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "asar": "~0.1.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
This allows building installers for apps that use the app.asar format rather than the app/ directory.