### PR TITLE
Future-proof the nuspec file a bit

### DIFF
--- a/template.nuspec
+++ b/template.nuspec
@@ -13,12 +13,12 @@
   <files>
     <file src="locales\**" target="lib\net45\locales" />
     <file src="resources\**" target="lib\net45\resources" />
-    <file src="*.pak" target="lib\net45" />
     <file src="*.bin" target="lib\net45" />
-    <file src="Update.exe" target="lib\net45\squirrel.exe" />
-    <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
     <file src="*.dll" target="lib\net45" />
+    <file src="*.pak" target="lib\net45" />
+    <file src="Update.exe" target="lib\net45\squirrel.exe" />
     <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
     <file src="LICENSE" target="lib\net45\LICENSE" />
+    <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
   </files>
 </package>

--- a/template.nuspec
+++ b/template.nuspec
@@ -14,10 +14,11 @@
     <file src="locales\**" target="lib\net45\locales" />
     <file src="resources\**" target="lib\net45\resources" />
     <file src="*.pak" target="lib\net45" />
+    <file src="*.bin" target="lib\net45" />
     <file src="Update.exe" target="lib\net45\squirrel.exe" />
     <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
     <file src="chromiumcontent.dll" target="lib\net45\chromiumcontent.dll" />
-    <file src="d3dcompiler_47.dll" target="lib\net45\d3dcompiler_47.dll" />
+    <file src="d3dcompiler_*.dll" target="lib\net45" />
     <file src="ffmpegsumo.dll" target="lib\net45\ffmpegsumo.dll" />
     <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
     <file src="libEGL.dll" target="lib\net45\libEGL.dll" />
@@ -27,7 +28,5 @@
     <file src="msvcr120.dll" target="lib\net45\msvcr120.dll" />
     <file src="vccorlib120.dll" target="lib\net45\vccorlib120.dll" />
     <file src="xinput1_3.dll" target="lib\net45\xinput1_3.dll" />
-    <file src="natives_blob.bin" target="lib\net45\natives_blob.bin" />
-    <file src="snapshot_blob.bin" target="lib\net45\snapshot_blob.bin" />
   </files>
 </package>

--- a/template.nuspec
+++ b/template.nuspec
@@ -17,16 +17,8 @@
     <file src="*.bin" target="lib\net45" />
     <file src="Update.exe" target="lib\net45\squirrel.exe" />
     <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
-    <file src="chromiumcontent.dll" target="lib\net45\chromiumcontent.dll" />
-    <file src="d3dcompiler_*.dll" target="lib\net45" />
-    <file src="ffmpegsumo.dll" target="lib\net45\ffmpegsumo.dll" />
+    <file src="*.dll" target="lib\net45" />
     <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
-    <file src="libEGL.dll" target="lib\net45\libEGL.dll" />
-    <file src="libGLESv2.dll" target="lib\net45\libGLESv2.dll" />
     <file src="LICENSE" target="lib\net45\LICENSE" />
-    <file src="msvcp120.dll" target="lib\net45\msvcp120.dll" />
-    <file src="msvcr120.dll" target="lib\net45\msvcr120.dll" />
-    <file src="vccorlib120.dll" target="lib\net45\vccorlib120.dll" />
-    <file src="xinput1_3.dll" target="lib\net45\xinput1_3.dll" />
   </files>
 </package>


### PR DESCRIPTION
This PR makes it so we won't have to bump the d3dcompiler version ever again or worry about new bin files showing up in future releases of Chrome